### PR TITLE
pass in library path for statically linked nginx binary

### DIFF
--- a/chroot-nginx.sh
+++ b/chroot-nginx.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ## Based on:
 ## https://github.com/doublerebel/nginx-chroot
 
@@ -30,6 +31,6 @@ grep nobody /etc/gshadow > ${NGINX_JAIL}/etc/gshadow
 cp -fv /etc/{services,adjtime,shells,hosts.deny,localtime,nsswitch.conf,protocols,ld.so.cache,ld.so.conf,host.conf} ${NGINX_JAIL}/etc
 
 echo "Testing chrooted nginx..."
-/usr/sbin/chroot /home/nginx /usr/local/nginx/sbin/nginx -t
+LD_LIBRARY_PATH=/lib/ /usr/sbin/chroot /home/nginx /usr/local/nginx/sbin/nginx -t
 
 exit 0

--- a/init.sh
+++ b/init.sh
@@ -5,6 +5,6 @@ if [ -z $NS_EXISTS ]; then
   exit -1
 fi
 
-ip netns exec nginx chroot /home/nginx /usr/local/nginx/sbin/nginx
+LD_LIBRARY_PATH=/lib/ ip netns exec nginx chroot /home/nginx /usr/local/nginx/sbin/nginx
 service php5-fpm start
 /etc/init.d/tor-chroot start &> /dev/null


### PR DESCRIPTION
Fixes an error where a call to `getpwnam` in the statically compiled nginx binary couldn't find the shared libraries it was made from:

```
nginx: [emerg] getpwnam("nobody") failed
```

Compilation warning when compiling nginx:

```
warning: Using 'getpwnam' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```
